### PR TITLE
Fix Team printing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 scripts/
 .pyc
+myenv/

--- a/LeagueRunner.py
+++ b/LeagueRunner.py
@@ -281,8 +281,8 @@ class Team:
                                 flex = player_list[player.adp - 1]
                                 break
                             te_found += 1
-                        repr_string += "  " + player_list[player.adp - 1] + "\n"
-        repr_string += "Flex:\n  " + flex + "\n"
+                        repr_string += "{} \n".format(player_list[player.adp - 1])
+        repr_string += "Flex:\n  {}\n".format(flex)
         repr_string += "\n"
         return repr_string
 


### PR DESCRIPTION
I ran into this error when trying to print out `team` inside of the `draft_player` function in robot1.py: 

```
File "LeagueRunner.py", line 284, in __repr__
    repr_string += "  " + player_list[player.adp - 1] + "\n"
TypeError: Can't convert 'Player' object to str implicitly
```

I'm not sure exactly why this error was occurring since I'm pretty sure `player_list[player.adp - 1]` returns a string, but using string interpolation fixed the issue.
